### PR TITLE
Libera la versión de nokogiri

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,7 @@ source 'https://rubygems.org'
 
 gemspec
 
-# para tener compatibilidad con Savon 2
-gem 'nokogiri', '~>1.5.11'
+gem 'nokogiri'
 group :test do
   gem 'rake'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     cfdi (0.2.2)
-      nokogiri (~> 1.5.11)
+      nokogiri
 
 GEM
   remote: https://rubygems.org/
@@ -10,7 +10,9 @@ GEM
     coderay (1.1.0)
     diff-lcs (1.2.5)
     method_source (0.8.2)
-    nokogiri (1.5.11)
+    mini_portile2 (2.0.0)
+    nokogiri (1.6.7.2)
+      mini_portile2 (~> 2.0.0.rc2)
     pry (0.10.1)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -31,10 +33,10 @@ PLATFORMS
 
 DEPENDENCIES
   cfdi!
-  nokogiri (~> 1.5.11)
+  nokogiri
   pry
   rake
   rspec
 
 BUNDLED WITH
-   1.10.6
+   1.12.5

--- a/cfdi.gemspec
+++ b/cfdi.gemspec
@@ -20,9 +20,9 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
   gem.rdoc_options  = '--no-private'
-  
-  gem.add_runtime_dependency 'nokogiri', '~>1.5.11'
+
+  gem.add_runtime_dependency 'nokogiri'
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'pry'
-  
+
 end

--- a/lib/cfdi.rb
+++ b/lib/cfdi.rb
@@ -1,5 +1,5 @@
 # encoding: utf-8
-gem 'nokogiri', '1.5.11'
+gem 'nokogiri'
 
 require_relative 'version.rb'
 require_relative 'comun.rb'
@@ -14,12 +14,12 @@ require_relative 'certificado.rb'
 require_relative 'key.rb'
 
 # Comprobantes fiscales digitales por los internets
-# 
+#
 # El sistema de generación y sellado de facturas es una patada en los genitales. Este gem pretende ser una bolsa de hielos. Igual va a doler, pero espero que al menos no quede moretón.
 module CFDI
 
   require 'nokogiri'
   require 'time'
   require 'base64'
-  
+
 end


### PR DESCRIPTION
Para que se pueda usar con Rails 4.2.6 o posterior
